### PR TITLE
fix: rounded up attendance percentage

### DIFF
--- a/frontend/components/user/Statistics.tsx
+++ b/frontend/components/user/Statistics.tsx
@@ -59,11 +59,11 @@ const Statistics = () => {
       value:
         attendanceRatio.attendanceRatio.attendance &&
         attendanceRatio.attendanceRatio.totalClasses
-          ? `${
+          ? `${Math.floor(
               (attendanceRatio.attendanceRatio.attendance /
                 attendanceRatio.attendanceRatio.totalClasses) *
-              100
-            }%`
+                100
+            )}%`
           : 0,
       icon: <GiPieChart />,
     },


### PR DESCRIPTION
**Title:** Round Down Attendance Percentage to Nearest Integer Using `Math.floor()`

**Description:**

This pull request updates the calculation of the attendance percentage to use `Math.floor()`, ensuring that the percentage is always rounded down to the nearest integer. By applying `Math.floor()` directly within the template literal, we remove any decimal points from the output, which provides a cleaner and more consistent display of the attendance percentage.

**Changes:**
- Updated the attendance percentage calculation to use `Math.floor()`.
- Ensured that the displayed percentage is always a whole number, preventing any fractional values.

**Before:**
- Attendance percentage could show decimal values (e.g., `85.9%`).

**After:**
- Attendance percentage is rounded down to the nearest integer (e.g., `85%`).

**Reason for Change:**
This change improves the clarity of the attendance display by removing decimal values and providing a straightforward percentage representation.